### PR TITLE
Using no_intervals.bed from assets data

### DIFF
--- a/assets/no_intervals.bed
+++ b/assets/no_intervals.bed
@@ -1,0 +1,1 @@
+no_intervals

--- a/main.nf
+++ b/main.nf
@@ -849,8 +849,7 @@ bedIntervals = bedIntervals
 bedIntervals = bedIntervals.dump(tag:'bedintervals')
 
 if (params.no_intervals && step != 'annotate') {
-    file("${params.outdir}/no_intervals.bed").text = "no_intervals\n"
-    bedIntervals = Channel.from(file("${params.outdir}/no_intervals.bed"))
+    bedIntervals = Channel.from(file("${projectDir}/assets/no_intervals.bed"))
 }
 
 (intBaseRecalibrator, intApplyBQSR, intHaplotypeCaller, intFreebayesSingle, intMpileup, bedIntervals) = bedIntervals.into(6)


### PR DESCRIPTION
It was not abe to create a file on results directory with the previous implentation, So created that file in assets and using that directly instead - 

```diff
-file("${params.outdir}/no_intervals.bed").text = "no_intervals\n"    
-bedIntervals = Channel.from(file("${params.outdir}/no_intervals.bed"))    
+bedIntervals = Channel.from(file("${projectDir}/assets/no_intervals.bed"))
```